### PR TITLE
use steps animation type for animated textures

### DIFF
--- a/src/hexdoc/_templates/textures.jcss.jinja
+++ b/src/hexdoc/_templates/textures.jcss.jinja
@@ -1,6 +1,6 @@
 {% for animation in animations %}
   .{{ animation.css_class }} {
-    animation: {{ animation.css_class }} {{ animation.time_seconds }}s linear infinite;
+    animation: {{ animation.css_class }} {{ animation.time_seconds }}s steps(1, start) infinite;
     background-size: 100%;
     background-image: url("{{ animation.url }}");
   }


### PR DESCRIPTION
prevents glitchy scrolling effect. especially obvious on Firefox (and maybe other browsers) for the first few seconds after the page loads (try https://hexcasting.hexxy.media/v/0.11.2/1.0/en_us/#items/pigments)

also, userstyle if you'd like to test (Stylus et al):
```css
/* ==UserStyle==
@name           Hexdoc animated texture demo
@namespace      github.com/openstyles/stylus
@version        1.0.0
@description    A new userstyle
@author         Me
==/UserStyle== */

@-moz-document url-prefix("https://hexcasting.hexxy.media") {
    .animated-sync.animated-sync {
        animation-timing-function: steps(1, start);
    }
}
```