### PR TITLE
Configure hatch-fancy-pypi-readme to exclude Contributing section (fi…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hexdoc"
-dynamic = ["version, "readme""]
+dynamic = ["version", "readme"]
 description = "Python web book docgen for Patchouli and Hex Casting."
 authors = [
     { name="object-Object" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "hatchling>=1.19.0",
     "hatch-regex-commit",
+        "hatch-fancy-pypi-readme",
 ]
 build-backend = "hatchling.build"
 
@@ -9,13 +10,12 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hexdoc"
-dynamic = ["version"]
+dynamic = ["version, "readme""]
 description = "Python web book docgen for Patchouli and Hex Casting."
 authors = [
     { name="object-Object" },
     { name="Alwinfy" },
 ]
-readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["hexdoc"]
 classifiers = [
@@ -252,3 +252,12 @@ reportUnusedVariable = "warning"
 
 reportMissingTypeStubs = "none"
 reportDuplicateImport = "none"
+
+
+# hatch-fancy-pypi-readme configuration
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+end-before = "## Contributing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "hatchling>=1.19.0",
     "hatch-regex-commit",
-        "hatch-fancy-pypi-readme",
+    "hatch-fancy-pypi-readme",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
…xes #99)

- Added hatch-fancy-pypi-readme to build dependencies
- Made readme field dynamic in project metadata
- Removed static readme = "README.md" line
- Configured hatch-fancy-pypi-readme to include README content up to "## Contributing" section

This ensures the Contributing section (which is only relevant for GitHub contributors) is excluded from the PyPI package description while remaining in the GitHub README.